### PR TITLE
[FIX] Addons path sequence issue while setup with Enterprise Edition

### DIFF
--- a/install_odoo_ubuntu.sh
+++ b/install_odoo_ubuntu.sh
@@ -201,7 +201,7 @@ fi
 sudo su root -c "printf 'logfile = /var/log/${OE_USER}/${OE_CONFIG}.log\n' >> /etc/${OE_CONFIG}.conf"
 
 if [ $IS_ENTERPRISE = "True" ]; then
-    sudo su root -c "printf 'addons_path=${OE_HOME}/enterprise/addons,${OE_HOME_EXT}/addons\n' >> /etc/${OE_CONFIG}.conf"
+    sudo su root -c "printf 'addons_path=${OE_HOME_EXT}/addons,${OE_HOME}/enterprise/addons\n' >> /etc/${OE_CONFIG}.conf"
 else
     sudo su root -c "printf 'addons_path=${OE_HOME_EXT}/addons,${OE_HOME}/custom/addons\n' >> /etc/${OE_CONFIG}.conf"
 fi


### PR DESCRIPTION
### [Fix] Addons loading sequence issue

**Issue:** Odoo config file is loading enterprise addons first, instead of the odoo base module

`File "/opt/odoo/enterprise/addons/web/controllers/main.py", line 34, in <module>
    from odoo.addons.base.models.qweb import QWeb
ModuleNotFoundError: No module named 'odoo.addons.base.models.qweb'`


**Solution:** Change the sequence of the addons folder. Load odoo base addons first then odoo enterprise addons